### PR TITLE
Open README as UTF-8 (Python3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 try:
   import os
   from setuptools import setup, find_packages
@@ -6,7 +7,10 @@ except ImportError:
   from distutils.core import setup
 
 try:
-    readme = open("README.rst", encoding="utf8")
+    if sys.version_info[:2] <= (2, 7):
+        readme = open("README.rst")
+    else:
+        readme = open("README.rst", encoding="utf8")
     long_description = str(readme.read())
 finally:
     readme.close()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
   from distutils.core import setup
 
 try:
-    readme = open("README.rst")
+    readme = open("README.rst", encoding="utf8")
     long_description = str(readme.read())
 finally:
     readme.close()


### PR DESCRIPTION
On Windows with Python 3.4, if I try to install your package with pip or setup.py after cloning the repo, I get an error about encoding:

```
Collecting vocabulary
  Downloading Vocabulary-0.0.4.tar.gz
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "vocabulary\setup.py", line 10, in <module>
        long_description = str(readme.read())
      File "python\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 5330: character maps to <undefined>
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

      File "<string>", line 20, in <module>

      File "vocabulary\setup.py", line 10, in <module>

        long_description = str(readme.read())

      File "python\lib\encodings\cp1252.py", line 23, in decode

        return codecs.charmap_decode(input,self.errors,decoding_table)[0]

    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 5330: character maps to <undefined>
```


If we explicitly pass `encoding="utf8"` to `open` the installation goes off without a hitch in Python 3.4.