### PR TITLE
Improving test coverage for invalid phrases

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,7 @@ except ImportError:
 class TestModule(unittest.TestCase):
     """Checks for the sanity of all module methods"""
 
-    def test_meaning(self):
+    def test_meaning_valid_phrase(self):
         current_result = vb.meaning("humming")
         result = '[{"seq": 0, "text": "Present participle of hum."}]'
         middle_val = json.loads(result)
@@ -34,7 +34,11 @@ class TestModule(unittest.TestCase):
 
             self.assertCountEqual(current_result, expected_result)
 
-    def test_synonym(self):
+    def test_meaning_not_valid_phrase(self):
+        current_result = vb.meaning("sxsw")
+        self.assertFalse(current_result)
+        
+    def test_synonym_valid_phrase(self):
         current_result = vb.synonym("repudiate")
         result = '[{"seq": 0, "text": "deny"}]'
         middle_val = json.loads(result)
@@ -44,7 +48,11 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_antonym_1(self):
+    def test_synonym_not_valid_phrase(self):
+        current_result = vb.synonym("sxsw")
+        self.assertFalse(current_result)
+        
+    def test_antonym_valid_phrase_1(self):
         current_result = vb.antonym("love")
         result = '{"text": ["hate"]}'
         expected_result = json.loads(result)
@@ -53,7 +61,7 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_antonym_2(self):
+    def test_antonym_valid_phrase_2(self):
         current_result = vb.antonym("respect")
         result = '{"text": ["disesteem", "disrespect"]}'
         expected_result = json.loads(result)
@@ -62,7 +70,11 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_partOfSpeech_1(self):
+    def test_antonym_not_valid_phrase(self):
+        current_result = vb.antonym("sxsw")
+        self.assertFalse(current_result)
+
+    def test_partOfSpeech_valid_phrase_1(self):
         current_result = vb.part_of_speech("hello")
         result = '[{"text": "interjection", "example:": "Used to greet someone, answer the telephone, or express surprise.", "seq": 0}]'
         middle_val = json.loads(result)
@@ -72,7 +84,7 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_partOfSpeech_2(self):
+    def test_partOfSpeech_valid_phrase_2(self):
         current_result = vb.part_of_speech("rapidly")
         result = '[{"text": "adverb", "example:": "With speed; in a rapid manner.", "seq": 0}]'
         middle_val = json.loads(result)
@@ -82,8 +94,12 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_usageExamples1(self):
-        current_result = vb.usage_example("hillock") # for valid word
+    def test_partOfSpeech_not_valid_phrase(self):
+        current_result = vb.part_of_speech("sxsw")
+        self.assertFalse(current_result)
+
+    def test_usageExamples_valid_phrase(self):
+        current_result = vb.usage_example("hillock")
         result = '[{"seq": 0, "text": "I went to the to of the hillock to look around."}]'
         middle_val = json.loads(result)
         expected_result = json.dumps(middle_val)
@@ -92,13 +108,12 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_usageExamples2(self):
-        current_result = vb.usage_example("lksj") # # for non valid word
-        expected_result = False
-        self.assertEqual(current_result, expected_result)
+    def test_usageExamples_not_valid_phrase(self):
+        current_result = vb.usage_example("lksj")
+        self.assertFalse(current_result)
 
-    def test_pronunciation1(self):
-        current_result = vb.pronunciation("hippopotamus") # for valid word
+    def test_pronunciation_valid_phrase(self):
+        current_result = vb.pronunciation("hippopotamus")
         result = '[{"rawType": "ahd-legacy", "raw": "(hĭpˌə-pŏtˈə-məs)", "seq": 0}, {"rawType": "arpabet", "raw": "HH IH2 P AH0 P AA1 T AH0 M AH0 S", "seq": 0}]'
         expected_result = json.loads(result)
         if sys.version_info[:2] <= (2, 7):
@@ -106,12 +121,11 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_pronunciation2(self):
+    def test_pronunciation_not_valid_phrase(self):
         current_result = vb.pronunciation("lksj") # for non valid word
-        expected_result = False
-        self.assertEqual(current_result, expected_result)
+        self.assertFalse(current_result)
 
-    def test_hyphenation(self):
+    def test_hyphenation_valid_phrase(self):
         current_result = vb.hyphenation("hippopotamus")
         result = '[{"seq": 0, "text": "hip", "type": "secondary stress"}, {"seq": 1, "text": "po"}, {"seq": 2, "text": "pot", "type": "stress"}, {"seq": 3, "text": "a"}, {"seq": 4, "text": "mus"}]'
         middle_val = json.loads(result)
@@ -121,7 +135,11 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_translate1(self):
+    def test_hyphenation_not_valid_phrase(self):
+        current_result = vb.hyphenation("sxsw")
+        self.assertFalse(current_result)
+
+    def test_translate_valid_phrase(self):
         current_result = vb.translate("hummus", "en", "es")
         result = '[{"text": "hummus", "seq": 0}]'
         middle_val = json.loads(result)
@@ -131,7 +149,7 @@ class TestModule(unittest.TestCase):
         else:
             self.assertCountEqual(current_result, expected_result)
 
-    def test_translate2(self):
+    def test_translate_not_valid_phrase(self):
         current_result = vb.translate("asldkfj", "en", "ru")
         self.assertEqual(current_result, False)
 

--- a/vocabulary/vocabulary.py
+++ b/vocabulary/vocabulary.py
@@ -153,7 +153,7 @@ class Vocabulary(object):
         :param phrase: word for which meaning is to be found
         :param source_lang: Defaults to : "en"
         :param dest_lang: Defaults to : "en" For eg: "fr" for french
-        :returns: returns a json object
+        :returns: returns a json object as str, False if invalid phrase
         """
         base_url = Vocabulary.__get_api_link("glosbe")
         url = base_url.format(word=phrase, source_lang=source_lang, dest_lang=dest_lang)
@@ -180,7 +180,7 @@ class Vocabulary(object):
         :param phrase:  word for which synonym is to be found
         :param source_lang: Defaults to : "en"
         :param dest_lang: Defaults to : "en"
-        :returns: returns a json object
+        :returns: returns a json object as str, False if invalid phrase
         """
         base_url = Vocabulary.__get_api_link("glosbe")
         url = base_url.format(word=phrase, source_lang=source_lang, dest_lang=dest_lang)
@@ -217,7 +217,7 @@ class Vocabulary(object):
             :param phrase:  word for which translation is being found
             :param source_lang: Translation from language
             :param dest_lang: Translation to language
-            :returns: returns a json object
+            :returns: returns a json object as str, False if invalid phrase
             """
             base_url = Vocabulary.__get_api_link("glosbe")
             url = base_url.format(word=phrase, source_lang=source_lang, dest_lang=dest_lang)
@@ -294,7 +294,7 @@ class Vocabulary(object):
         querrying Wordnik's API for knowing whether the word is a noun, adjective and the like
 
         :params phrase: word for which part_of_speech is to be found
-        :returns: returns a json object
+        :returns: returns a json object as str, False if invalid phrase
         """
         ## We get a list object as a return value from the Wordnik API
         base_url = Vocabulary.__get_api_link("wordnik")
@@ -326,7 +326,7 @@ class Vocabulary(object):
         """Takes the source phrase and queries it to the urbandictionary API
 
         :params phrase: word for which usage_example is to be found
-        :returns: returns a json object
+        :returns: returns a json object as str, False if invalid phrase
         """
         base_url = Vocabulary.__get_api_link("urbandict")
         url = base_url.format(action="define", word=phrase)
@@ -352,7 +352,7 @@ class Vocabulary(object):
         Gets the pronunciation from the Wordnik API
 
         :params phrase: word for which pronunciation is to be found
-        :returns: returns a list object
+        :returns: returns a list object, False if invalid phrase
         """
         base_url = Vocabulary.__get_api_link("wordnik")
         url = base_url.format(word=phrase, action="pronunciations")
@@ -372,7 +372,7 @@ class Vocabulary(object):
         Returns back the stress points in the "phrase" passed
 
         :param phrase: word for which hyphenation is to be found
-        :returns: returns a json object
+        :returns: returns a json object as str, False if invalid phrase
         """
         base_url = Vocabulary.__get_api_link("wordnik")
         url = base_url.format(word=phrase, action="hyphenation")


### PR DESCRIPTION
Enumeration is fine for essentially duplicated tests like
test_partOfSpeech_2. The two test_pronunciation tests and two
test_usageExamples tests are testing valid and invalid words, which are
different tests.

Including invalid phrase tests for all public methods.

In source, documented the return False for invalid phrases